### PR TITLE
Uses URL constructor to reliably generate the url

### DIFF
--- a/lib/captcha.js
+++ b/lib/captcha.js
@@ -35,11 +35,10 @@ const solve = async (response) => {
           body.push('h-captcha-response=' + captchaResponse);
         }
 
-        const baseUrl = response.url.substring(0, response.url.lastIndexOf('/'));
         const { method, action, enctype } = document.getElementById('challenge-form');
         return {
           method,
-          url: action.startsWith('/') ? baseUrl + action : action,
+          url: new URL(action, response.url),
           headers: {
             'content-type': enctype, // application/x-www-form-urlencoded
           },


### PR DESCRIPTION
This fixes the form submit URL when the request is not to the root path. Using the lastIndexOf "/" will get the last directory, but it always needs to be the root. So, for example, if the page being attempted is `https://bouqs.com/flowers/all` and the action is `/flowers/all`, the existing code would generate `https://bouqs.com/flowers/flowers/all`. The URL constructor can intelligently generate the URL from a given base: https://nodejs.org/api/url.html#url_constructor_new_url_input_base