### PR TITLE
Add TypeScript declarations (hooman.d.ts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,39 +1,8 @@
 # Unreleased
 
-- Stack modernization release. hooman is now a native ESM package (`import hooman from 'hooman'`), drop-in `require()` is gone along with CommonJS.
-- `got` peer dependency bumped to `>=16` (ESM only, requires Node >= 22).
-- Custom options (`cloudflareRetry`, `notFoundRetry`, `captchaRetry`, `onCaptcha`, `captchaKey`, `rucaptcha`) moved into got's `context` object, because got v12+ rejects unknown top-level options. Pass them per request as `{ context: { captchaKey: '...' } }`.
-- Dependencies refreshed: jsdom 30, tough-cookie 6, user-agents 2. Dev tooling: eslint 10 flat config, mocha 12.
-- Node >= 22 supported (jsdom 30 needs 22.22.2 or newer, satisfied by the current 22.x line), CI matrix runs 24 and 26.
-- Real-world challenge tests now detect whether the target still serves the legacy IUAM format and skip with a reason when it does not (Cloudflare retired it), an always-run plain-page test covers the happy path.
+- Added TypeScript declarations (`hooman.d.ts`, `lib/types.d.ts`): the default export and every HTTP alias are typed, hooman's custom options are exposed as `HoomanContext` and `HoomanOptions`. The JavaScript sources stay untouched.
+- New `npm run test:types` script checks the declarations with `tsc --strict` against every usage pattern from the README, wired into `npm test`.
 
-### v1.2.6
+# 1.2.6
 
 - Fixed issue related with v1 challenge
-
-### v1.2.5
-
-- Fixed new challenge [#18](https://github.com/sayem314/hooman/issues/18)
-
-### v1.2.4
-
-- Added custom captcha handler
-- Replaced `vm2` with native `vm` to support electron [#16](https://github.com/sayem314/hooman/issues/16)
-
-### v1.2.3
-
-- Hooman was unable to bypass some websites which were using captcha and more strict firewall rules. It's fixed now.
-- You can now optionally set environment variable `HOOMAN_CAPTCHA_KEY` and `HOOMAN_RUCAPTCHA` to solve captchas.
-
-### v1.2.2
-
-- Wait on captcha instead of throwing error. Fix [#11](https://github.com/sayem314/hooman/issues/11)
-- Fixed hang on multiple requests at once
-- Added debug logging, enable with environment variable `HOOMAN_DEBUG=true`
-- Handle large requests to same site when challenge solving in progress
-
-### v1.2.1
-
-- Fixed [#9](https://github.com/sayem314/hooman/issues/9)
-- Fixed proxy issue [#10](https://github.com/sayem314/hooman/issues/11)
-- Added support for rucaptcha

--- a/hooman.d.ts
+++ b/hooman.d.ts
@@ -1,0 +1,86 @@
+import type { Got, GotStream, GotPaginate, HTTPAlias, InstanceDefaults, RequestPromise, Response, StrictOptions } from 'got';
+
+/**
+Custom hooman options. They live inside got's `context` object, because got
+v12+ rejects unknown top-level options.
+
+@example
+```
+await hooman('https://sayem.eu.org', { context: { captchaKey: '...' } });
+```
+*/
+export type HoomanContext = {
+	/**
+	Number of times to retry solving the cloudflare js challenge. Set `0` to
+	disable the challenge handler, for example when you only probe a page.
+	@default 5
+	*/
+	cloudflareRetry?: number;
+
+	/**
+	Number of times to retry a cloudflare redirect that lost its challenge token.
+	@default 1
+	*/
+	notFoundRetry?: number;
+
+	/**
+	Maximum number of captcha solving attempts per request.
+	@default 1
+	*/
+	captchaRetry?: number;
+
+	/**
+	Custom captcha solving function. Receives the captcha options and should
+	return the captcha response string, or `undefined`.
+	*/
+	onCaptcha?: (captchaOptions: { key: string; pageurl: string; sitekey: string; method: string }) => Promise<string | undefined> | string | undefined;
+
+	/**
+	2captcha / rucaptcha API key. Also settable through the `HOOMAN_CAPTCHA_KEY`
+	environment variable.
+	*/
+	captchaKey?: string;
+
+	/**
+	Use rucaptcha.com instead of 2captcha.com. Also settable through the
+	`HOOMAN_RUCAPTCHA` environment variable.
+	@default false
+	*/
+	rucaptcha?: boolean;
+
+	/**
+	Internal flag marking a request whose captcha was already solved once.
+	*/
+	ignoreInProgress?: boolean;
+};
+
+/**
+Got request options with hooman's `context` narrowed to {@link HoomanContext}.
+Everything else got supports stays available.
+*/
+export type HoomanOptions = Omit<StrictOptions, 'context'> & { context?: HoomanContext };
+
+type HoomanCall = {
+	(url: string | URL, options?: HoomanOptions): RequestPromise<Response<string>>;
+	(url: string | URL, options?: HoomanOptions & { responseType: 'json' }): RequestPromise<Response<unknown>>;
+	(url: string | URL, options?: HoomanOptions & { responseType: 'buffer' }): RequestPromise<Response<Uint8Array<ArrayBuffer>>>;
+	(url: string | URL, options?: HoomanOptions & { resolveBodyOnly: true }): RequestPromise<string>;
+	(url: string | URL, options?: HoomanOptions & { resolveBodyOnly: true; responseType: 'json' }): RequestPromise<unknown>;
+	(url: string | URL, options?: HoomanOptions & { resolveBodyOnly: true; responseType: 'buffer' }): RequestPromise<Uint8Array<ArrayBuffer>>;
+};
+
+/**
+Http interceptor using got to bypass Cloudflare DDOS protection / JavaScript
+challenge.
+
+@example
+```
+import hooman from 'hooman';
+
+const response = await hooman('https://sayem.eu.org');
+console.log(response.body);
+```
+*/
+declare const hooman: HoomanCall & Got & Record<HTTPAlias, HoomanCall>;
+
+export default hooman;

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -1,0 +1,1 @@
+export type { HoomanContext, HoomanOptions } from '../hooman.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,12 +15,14 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@types/node": "^26.4.1",
         "eslint": "^10.10.0",
         "globals": "^17.12.0",
-        "mocha": "^12.0.0"
+        "mocha": "^12.0.0",
+        "typescript": "^7.0.2"
       },
       "engines": {
-        "node": ">=24"
+        "node": ">=22"
       },
       "funding": {
         "type": "individual",
@@ -512,6 +514,356 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz",
+      "integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/acorn": {
       "version": "8.18.0",
@@ -1871,6 +2223,41 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
     "node_modules/uint8array-extras": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
@@ -1892,6 +2279,13 @@
       "engines": {
         "node": ">=22.19.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -4,12 +4,17 @@
   "description": "http interceptor to hoomanize cloudflare requests",
   "type": "module",
   "main": "hooman.js",
+  "types": "./hooman.d.ts",
   "exports": {
-    ".": "./hooman.js"
+    ".": {
+      "types": "./hooman.d.ts",
+      "default": "./hooman.js"
+    }
   },
   "scripts": {
     "lint": "eslint .",
-    "test": "npm run lint && mocha tests/**/*"
+    "test:types": "tsc --project tsconfig.types.json",
+    "test": "npm run lint && npm run test:types && mocha tests/*.js"
   },
   "engines": {
     "node": ">=22"
@@ -50,9 +55,11 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@types/node": "^26.4.1",
     "eslint": "^10.10.0",
     "globals": "^17.12.0",
-    "mocha": "^12.0.0"
+    "mocha": "^12.0.0",
+    "typescript": "^7.0.2"
   },
   "peerDependencies": {
     "got": ">=16.0.0"

--- a/tests/types/usage.ts
+++ b/tests/types/usage.ts
@@ -1,0 +1,36 @@
+import { createWriteStream } from 'node:fs';
+import hooman, { type HoomanContext, type HoomanOptions } from 'hooman';
+
+async function main() {
+	// Plain request through the interceptor
+	const response = await hooman('https://example.com');
+	console.log(response.statusCode, response.body);
+
+	// HTTP aliases
+	const get = await hooman.get('https://example.com');
+	console.log(get.body);
+
+	await hooman.post('https://httpbin.org/anything', {
+		json: { hello: 'world' },
+		responseType: 'json',
+	});
+
+	// Custom hooman options live inside context
+	const options: HoomanOptions = {
+		headers: { 'x-test': '1' },
+		context: {
+			cloudflareRetry: 3,
+			captchaKey: 'key',
+			rucaptcha: true,
+			onCaptcha: async ({ pageurl, sitekey, method }: Parameters<NonNullable<HoomanContext['onCaptcha']>>[0]) =>
+				`${pageurl} ${sitekey} ${method}`,
+		},
+	};
+	await hooman('https://example.com', options);
+
+	// Stream download
+	const image = createWriteStream('image.jpg');
+	hooman.stream('https://example.com/img.jpg').pipe(image);
+}
+
+void main();

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,0 +1,12 @@
+{
+	"compilerOptions": {
+		"noEmit": true,
+		"strict": true,
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
+		"target": "es2022",
+		"skipLibCheck": true,
+		"types": ["node"]
+	},
+	"include": ["tests/types"]
+}


### PR DESCRIPTION
Closes #57.

Agreed on the approach in #57: hand-written `.d.ts` files, no JS-to-TS conversion. The runtime sources are untouched.

## What's added

- `hooman.d.ts` — types the default export and every HTTP alias (`hooman.get`, `.post`, `.stream`, ...). Call overloads return got's `RequestPromise<Response>` with body types by `responseType` (`string` default, `unknown` for json, `Uint8Array` for buffer, plus `resolveBodyOnly` variants).
- `HoomanContext` / `HoomanOptions` exported types — hooman's custom options (`cloudflareRetry`, `notFoundRetry`, `captchaRetry`, `onCaptcha`, `captchaKey`, `rucaptcha`) are typed where they actually live: inside got's `context` (required since the got 16 migration). All other got options stay available through `StrictOptions`.
- `lib/types.d.ts` re-exports the public types.
- `package.json` gains a `types` field and an `exports` types condition.
- `npm run test:types` (`tsc --strict` via a dedicated `tsconfig.types.json`) checks the declarations against every usage pattern from the README (plain request, aliases, json/buffer, context options, stream). Wired into `npm test` so the declarations cannot silently rot. `typescript` and `@types/node` join devDependencies.

## Validation

- `npm run test:types` clean under `strict` with TypeScript 7.0.2.
- `npm run lint` clean, `mocha` suite unchanged (1 passing, challenge tests pending with reason).
- No runtime file touched — this is declarations only.