### PR TITLE
Bump to 2.0.0 and pin dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-# Unreleased
+# 2.0.0
 
+- Version bumped for the breaking stack modernization below.
+- Dependencies are pinned to exact versions (no caret ranges) to reduce supply-chain risk. `package-lock.json` locks the transitive tree, and the `got` peer dependency stays a floor range since consumers install and resolve it themselves.
 - Added TypeScript declarations (`hooman.d.ts`, `lib/types.d.ts`): the default export and every HTTP alias are typed, hooman's custom options are exposed as `HoomanContext` and `HoomanOptions`. The JavaScript sources stay untouched.
 - New `npm run test:types` script checks the declarations with `tsc --strict` against every usage pattern from the README, wired into `npm test`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,25 +1,25 @@
 {
   "name": "hooman",
-  "version": "1.2.6",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hooman",
-      "version": "1.2.6",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "jsdom": "^30.0.1",
-        "tough-cookie": "^6.0.0",
-        "user-agents": "^2.1.175"
+        "jsdom": "30.0.1",
+        "tough-cookie": "6.0.2",
+        "user-agents": "2.1.175"
       },
       "devDependencies": {
-        "@eslint/js": "^10.0.1",
-        "@types/node": "^26.4.1",
-        "eslint": "^10.10.0",
-        "globals": "^17.12.0",
-        "mocha": "^12.0.0",
-        "typescript": "^7.0.2"
+        "@eslint/js": "10.0.1",
+        "@types/node": "26.4.1",
+        "eslint": "10.10.0",
+        "globals": "17.12.0",
+        "mocha": "12.0.0",
+        "typescript": "7.0.2"
       },
       "engines": {
         "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hooman",
-  "version": "1.2.6",
+  "version": "2.0.0",
   "description": "http interceptor to hoomanize cloudflare requests",
   "type": "module",
   "main": "hooman.js",
@@ -49,17 +49,17 @@
   },
   "homepage": "https://github.com/sayem314/hooman#readme",
   "dependencies": {
-    "jsdom": "^30.0.1",
-    "tough-cookie": "^6.0.0",
-    "user-agents": "^2.1.175"
+    "jsdom": "30.0.1",
+    "tough-cookie": "6.0.2",
+    "user-agents": "2.1.175"
   },
   "devDependencies": {
-    "@eslint/js": "^10.0.1",
-    "@types/node": "^26.4.1",
-    "eslint": "^10.10.0",
-    "globals": "^17.12.0",
-    "mocha": "^12.0.0",
-    "typescript": "^7.0.2"
+    "@eslint/js": "10.0.1",
+    "@types/node": "26.4.1",
+    "eslint": "10.10.0",
+    "globals": "17.12.0",
+    "mocha": "12.0.0",
+    "typescript": "7.0.2"
   },
   "peerDependencies": {
     "got": ">=16.0.0"


### PR DESCRIPTION
Closes #59.

## Version

`2.0.0` — marks the breaking stack modernization already merged on master (native ESM, `got` 16 peer, Node >= 22, custom options under `context`). The changelog section that was `Unreleased` is now headed `2.0.0`.

## Pinned dependencies

All `dependencies` and `devDependencies` moved from caret ranges to the exact versions currently locked in `package-lock.json` (the same set CI and the test suite just ran against):

| Package | Pinned |
| --- | --- |
| jsdom | 30.0.1 |
| tough-cookie | 6.0.2 |
| user-agents | 2.1.175 |
| @eslint/js | 10.0.1 |
| @types/node | 26.4.1 |
| eslint | 10.10.0 |
| globals | 17.12.0 |
| mocha | 12.0.0 |
| typescript | 7.0.2 |

`package-lock.json` is regenerated and keeps locking the full transitive tree. The `got` **peer** dependency intentionally stays a floor range (`>=16.0.0`) — it is resolved by the consuming application, not installed by hooman.

## Validation

- `npm install` resolves the pinned set cleanly, `package-lock.json` diff is version-strips only.
- `npm run lint` clean, `npm run test:types` clean, live suite: 1 passing / 3 pending (challenge tests, reason as documented).